### PR TITLE
Fix NDI source attribute

### DIFF
--- a/src/ndi_viewer.py
+++ b/src/ndi_viewer.py
@@ -66,7 +66,7 @@ class NDIViewer(QtWidgets.QWidget):
         self.source_selector.blockSignals(True)
         self.source_selector.clear()
         for src in self.sources:
-            self.source_selector.addItem(src.p_ndi_name.decode("utf-8"))
+            self.source_selector.addItem(src.ndi_name)
         self.source_selector.blockSignals(False)
 
         if self.sources:

--- a/src/ndi_viewer_pyside6.py
+++ b/src/ndi_viewer_pyside6.py
@@ -81,7 +81,7 @@ class NDIViewer(QtWidgets.QMainWindow):
         self.combo.blockSignals(True)
         self.combo.clear()
         for src in self.sources:
-            name = src.p_ndi_name.decode("utf-8")
+            name = src.ndi_name
             ip = src.p_url_address.decode("utf-8") if src.p_url_address else ""
             display = f"{name} ({ip})" if ip else name
             self.combo.addItem(display)


### PR DESCRIPTION
## Summary
- correct NDI source name attribute in both viewer examples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e7f0ac91c83258a99b14befe3c390