### PR TITLE
Fix NDI FrameType constants

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -118,7 +118,7 @@ class MainWindow(QtWidgets.QMainWindow):
             return
 
         frame_type, video_frame, _, _ = ndi.recv_capture_v2(self.receiver, 1000)
-        if frame_type == ndi.FrameType.VIDEO:
+        if frame_type == ndi.FRAME_TYPE_VIDEO:
             h = video_frame.yres
             w = video_frame.xres
             data = np.frombuffer(video_frame.data, dtype=np.uint8)

--- a/src/ndi_viewer.py
+++ b/src/ndi_viewer.py
@@ -88,7 +88,7 @@ class NDIViewer(QtWidgets.QWidget):
         frame_type, video_frame, _audio_frame, _meta = ndi.recv_capture_v2(
             self.receiver, 1000
         )
-        if frame_type == ndi.FrameType.VIDEO:
+        if frame_type == ndi.FRAME_TYPE_VIDEO:
             height = video_frame.yres
             width = video_frame.xres
             data = np.frombuffer(video_frame.data, dtype=np.uint8)

--- a/src/ndi_viewer_pyside6.py
+++ b/src/ndi_viewer_pyside6.py
@@ -120,7 +120,7 @@ class NDIViewer(QtWidgets.QMainWindow):
         if self.receiver is None:
             return
         frame_type, video_frame, _, _ = ndi.recv_capture_v2(self.receiver, 1000)
-        if frame_type == ndi.FrameType.VIDEO:
+        if frame_type == ndi.FRAME_TYPE_VIDEO:
             h = video_frame.yres
             w = video_frame.xres
             data = np.frombuffer(video_frame.data, dtype=np.uint8)


### PR DESCRIPTION
## Summary
- use NDI `FRAME_TYPE_*` constants instead of nonexistent `FrameType.VIDEO`
- adjust PyQt and PySide viewers accordingly

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687e9c73510c8325aeefaa175cde77f1