### PR TITLE
Fix NDI frame type handling

### DIFF
--- a/src/ndi_viewer_pyside6.py
+++ b/src/ndi_viewer_pyside6.py
@@ -1,4 +1,6 @@
 import sys
+import logging
+
 import numpy as np
 import cv2
 from PySide6 import QtCore, QtGui, QtWidgets
@@ -119,7 +121,9 @@ class NDIViewer(QtWidgets.QMainWindow):
     def _update_frame(self):
         if self.receiver is None:
             return
-        frame_type, video_frame, _, _ = ndi.recv_capture_v2(self.receiver, 1000)
+        frame_type, video_frame, audio_frame, metadata_frame = ndi.recv_capture_v2(
+            self.receiver, 1000
+        )
         if frame_type == ndi.FRAME_TYPE_VIDEO:
             h = video_frame.yres
             w = video_frame.xres
@@ -129,11 +133,14 @@ class NDIViewer(QtWidgets.QMainWindow):
             qimg = QtGui.QImage(frame.data, w, h, QtGui.QImage.Format_RGB888)
             self.video_label.setPixmap(QtGui.QPixmap.fromImage(qimg))
             ndi.recv_free_video_v2(self.receiver, video_frame)
-        elif frame_type == ndi.FrameType.ERROR:
-            self.video_label.setText("Error receiving video")
-            self._disconnect_receiver()
-        else:
+        elif frame_type == ndi.FRAME_TYPE_AUDIO:
+            ndi.recv_free_audio_v2(self.receiver, audio_frame)
+        elif frame_type == ndi.FRAME_TYPE_METADATA:
+            ndi.recv_free_metadata(self.receiver, metadata_frame)
+        elif frame_type == ndi.FRAME_TYPE_NONE:
             pass
+        else:
+            logging.warning("Unknown NDI frame type: %s", frame_type)
 
 
 def main():


### PR DESCRIPTION
## Summary
- update `NDI` frame checks to match sdk enums
- ignore or free audio/metadata frames and log unknown frame types
- add `logging` imports

## Testing
- `flake8 src/gui/main_window.py src/ndi_viewer.py src/ndi_viewer_pyside6.py`
- `python -m py_compile src/gui/main_window.py src/ndi_viewer.py src/ndi_viewer_pyside6.py`

------
https://chatgpt.com/codex/tasks/task_e_687e9ebcff7483258b9da3a2734580f7