### PR TITLE
Handle NDI status change frames

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -119,26 +119,38 @@ class MainWindow(QtWidgets.QMainWindow):
         if self.receiver is None or ndi is None:
             return
 
-        frame_type, video_frame, audio_frame, metadata_frame = ndi.recv_capture_v2(
-            self.receiver, 1000
-        )
-        if frame_type == ndi.FRAME_TYPE_VIDEO:
-            h = video_frame.yres
-            w = video_frame.xres
-            data = np.frombuffer(video_frame.data, dtype=np.uint8)
-            data = data.reshape(h, video_frame.line_stride_in_bytes // 4, 4)
-            frame = cv2.cvtColor(data, cv2.COLOR_BGRA2RGB)
-            qimg = QtGui.QImage(frame.data, w, h, QtGui.QImage.Format_RGB888)
-            self.video_label.setPixmap(QtGui.QPixmap.fromImage(qimg))
-            ndi.recv_free_video_v2(self.receiver, video_frame)
-        elif frame_type == ndi.FRAME_TYPE_AUDIO:
-            ndi.recv_free_audio_v2(self.receiver, audio_frame)
-        elif frame_type == ndi.FRAME_TYPE_METADATA:
-            ndi.recv_free_metadata(self.receiver, metadata_frame)
-        elif frame_type == ndi.FRAME_TYPE_NONE:
-            pass
-        else:
-            logging.warning("Unknown NDI frame type: %s", frame_type)
+        timeout = 1000
+        while True:
+            frame_type, video_frame, audio_frame, metadata_frame = ndi.recv_capture_v2(
+                self.receiver, timeout
+            )
+            # subsequent iterations should return immediately
+            timeout = 0
+
+            if frame_type == ndi.FRAME_TYPE_VIDEO:
+                h = video_frame.yres
+                w = video_frame.xres
+                data = np.frombuffer(video_frame.data, dtype=np.uint8)
+                data = data.reshape(h, video_frame.line_stride_in_bytes // 4, 4)
+                frame = cv2.cvtColor(data, cv2.COLOR_BGRA2RGB)
+                qimg = QtGui.QImage(frame.data, w, h, QtGui.QImage.Format_RGB888)
+                self.video_label.setPixmap(QtGui.QPixmap.fromImage(qimg))
+                ndi.recv_free_video_v2(self.receiver, video_frame)
+                break
+            elif frame_type == ndi.FRAME_TYPE_AUDIO:
+                ndi.recv_free_audio_v2(self.receiver, audio_frame)
+                continue
+            elif frame_type == ndi.FRAME_TYPE_METADATA:
+                ndi.recv_free_metadata(self.receiver, metadata_frame)
+                continue
+            elif frame_type == ndi.FRAME_TYPE_STATUS_CHANGE:
+                # Source status changed, ignore and wait for next frame
+                continue
+            elif frame_type == ndi.FRAME_TYPE_NONE:
+                break
+            else:
+                logging.warning("Unknown NDI frame type: %s", frame_type)
+                break
 
 
 def main():


### PR DESCRIPTION
## Summary
- keep polling frames until a real video frame is received
- ignore NDI status changes instead of treating them as unknown
- release video frame buffers once processed

## Testing
- `pytest -q`
- `python -m py_compile src/gui/main_window.py src/ndi_viewer_pyside6.py`

------
https://chatgpt.com/codex/tasks/task_e_687ea0c96df88325bd905817cddafe36