### PR TITLE
Fix NDI status change constant

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -143,7 +143,7 @@ class MainWindow(QtWidgets.QMainWindow):
             elif frame_type == ndi.FRAME_TYPE_METADATA:
                 ndi.recv_free_metadata(self.receiver, metadata_frame)
                 continue
-            elif frame_type == ndi.FRAME_TYPE_STATUS_CHANGE:
+            elif frame_type == ndi.FRANE_TYPE_STATUS_CHANGE:
                 # Source status changed, ignore and wait for next frame
                 continue
             elif frame_type == ndi.FRAME_TYPE_NONE:

--- a/src/ndi_viewer_pyside6.py
+++ b/src/ndi_viewer_pyside6.py
@@ -144,7 +144,7 @@ class NDIViewer(QtWidgets.QMainWindow):
             elif frame_type == ndi.FRAME_TYPE_METADATA:
                 ndi.recv_free_metadata(self.receiver, metadata_frame)
                 continue
-            elif frame_type == ndi.FRAME_TYPE_STATUS_CHANGE:
+            elif frame_type == ndi.FRANE_TYPE_STATUS_CHANGE:
                 continue
             elif frame_type == ndi.FRAME_TYPE_NONE:
                 break


### PR DESCRIPTION
## Summary
- correct constant name for NDI status change frames
- update PySide example accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ea284d7808325a9c5bf9d0b9a5d82