### PR TITLE
Log frame types and handle status change

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1,5 +1,4 @@
 import sys
-import logging
 
 import numpy as np
 import cv2
@@ -126,8 +125,10 @@ class MainWindow(QtWidgets.QMainWindow):
             )
             # subsequent iterations should return immediately
             timeout = 0
+            print("Received frame type:", frame_type)
 
             if frame_type == ndi.FRAME_TYPE_VIDEO:
+                print("Processing video frame", video_frame.xres, video_frame.yres)
                 h = video_frame.yres
                 w = video_frame.xres
                 data = np.frombuffer(video_frame.data, dtype=np.uint8)
@@ -144,12 +145,13 @@ class MainWindow(QtWidgets.QMainWindow):
                 ndi.recv_free_metadata(self.receiver, metadata_frame)
                 continue
             elif frame_type == ndi.FRANE_TYPE_STATUS_CHANGE:
-                # Source status changed, ignore and wait for next frame
+                print("Status change event")
                 continue
             elif frame_type == ndi.FRAME_TYPE_NONE:
+                print("No frame this loop")
                 break
             else:
-                logging.warning("Unknown NDI frame type: %s", frame_type)
+                print("Unexpected frame type", frame_type)
                 break
 
 


### PR DESCRIPTION
## Summary
- print each received NDI frame type
- print video frame dimensions when processing video
- log status change and no-frame events
- remove unused logging import

## Testing
- `python -m py_compile src/gui/main_window.py`
- `flake8 src/gui/main_window.py` *(fails: line too long)*

------
https://chatgpt.com/codex/tasks/task_e_687ea73efd0c8325b601d893079e66b5