### PR TITLE
Add verbose logging for NDI video frame handling

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -120,38 +120,42 @@ class MainWindow(QtWidgets.QMainWindow):
 
         timeout = 1000
         while True:
-            frame_type, video_frame, audio_frame, metadata_frame = ndi.recv_capture_v2(
-                self.receiver, timeout
-            )
-            # subsequent iterations should return immediately
-            timeout = 0
-            print("Received frame type:", frame_type)
+            try:
+                frame_type, video_frame, _audio_frame, metadata_frame = ndi.recv_capture_v2(
+                    self.receiver, timeout
+                )
+                # subsequent iterations should return immediately
+                timeout = 0
+                print("Received frame type:", frame_type)
 
-            if frame_type == ndi.FRAME_TYPE_VIDEO:
-                print("Processing video frame", video_frame.xres, video_frame.yres)
-                h = video_frame.yres
-                w = video_frame.xres
-                data = np.frombuffer(video_frame.data, dtype=np.uint8)
-                data = data.reshape(h, video_frame.line_stride_in_bytes // 4, 4)
-                frame = cv2.cvtColor(data, cv2.COLOR_BGRA2RGB)
-                qimg = QtGui.QImage(frame.data, w, h, QtGui.QImage.Format_RGB888)
-                self.video_label.setPixmap(QtGui.QPixmap.fromImage(qimg))
-                ndi.recv_free_video_v2(self.receiver, video_frame)
-                break
-            elif frame_type == ndi.FRAME_TYPE_AUDIO:
-                ndi.recv_free_audio_v2(self.receiver, audio_frame)
-                continue
-            elif frame_type == ndi.FRAME_TYPE_METADATA:
-                ndi.recv_free_metadata(self.receiver, metadata_frame)
-                continue
-            elif frame_type == ndi.FRANE_TYPE_STATUS_CHANGE:
-                print("Status change event")
-                continue
-            elif frame_type == ndi.FRAME_TYPE_NONE:
-                print("No frame this loop")
-                break
-            else:
-                print("Unexpected frame type", frame_type)
+                if frame_type == ndi.FRAME_TYPE_VIDEO:
+                    print("Processing video frame", video_frame.xres, video_frame.yres)
+                    print("Converting to numpy array...")
+                    data = np.frombuffer(video_frame.data, dtype=np.uint8)
+                    print("Reshaping...")
+                    data = data.reshape(video_frame.yres, video_frame.line_stride_in_bytes // 4, 4)
+                    frame = cv2.cvtColor(data, cv2.COLOR_BGRA2RGB)
+                    print("Creating QImage...")
+                    qimg = QtGui.QImage(frame.data, video_frame.xres, video_frame.yres, QtGui.QImage.Format_RGB888)
+                    print("Displaying...")
+                    self.video_label.setPixmap(QtGui.QPixmap.fromImage(qimg))
+                    print("Done displaying frame")
+                    ndi.recv_free_video_v2(self.receiver, video_frame)
+                    break
+                elif frame_type == ndi.FRAME_TYPE_METADATA:
+                    ndi.recv_free_metadata(self.receiver, metadata_frame)
+                    continue
+                elif frame_type == ndi.FRANE_TYPE_STATUS_CHANGE:
+                    print("Status change event")
+                    continue
+                elif frame_type == ndi.FRAME_TYPE_NONE:
+                    print("No frame this loop")
+                    break
+                else:
+                    print("Unexpected frame type", frame_type)
+                    break
+            except Exception as e:
+                print(f"Exception during video frame handling: {e}")
                 break
 
 


### PR DESCRIPTION
## Summary
- add debug logging throughout video frame handling
- wrap NDI video frame processing in try/except
- remove audio frame processing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f86a4b2e88325bf5c2b03e6187bc9